### PR TITLE
PelTec Compact - add "compact" device type handling (same as "peltec")

### DIFF
--- a/custom_components/centrometal_boiler/sensor.py
+++ b/custom_components/centrometal_boiler/sensor.py
@@ -37,9 +37,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
         entities.extend(
             WebBoilerHeatingCircuitSensor.create_heating_circuits_entities(hass, device)
         )
-        if device["type"] == "peltec" or device["type"] == "biopl":
+        if device["type"] in ["peltec", "compact", "biopl"]:
             entities.extend(WebBoilerPelletLevelSensor.create_entities(hass, device))
-        if device["type"] == "peltec":
+        if device["type"] in ["peltec", "compact"]:
             entities.extend(WebBoilerFireGridSensor.create_entities(hass, device))
         entities.extend(WebBoilerGenericSensor.create_conf_entities(hass, device))
         entities.extend(

--- a/custom_components/centrometal_boiler/sensors/WebBoilerConfigurationSensor.py
+++ b/custom_components/centrometal_boiler/sensors/WebBoilerConfigurationSensor.py
@@ -8,7 +8,7 @@ class WebBoilerConfigurationSensor(WebBoilerGenericSensor):
     @property
     def native_value(self):
         """Return the value of the sensor."""
-        if self.device["type"] == "peltec":
+        if device["type"] in ["peltec", "compact"]:
             configurations = [
                 "1. DHW",
                 "2. DHC",

--- a/custom_components/centrometal_boiler/sensors/WebBoilerGenericSensor.py
+++ b/custom_components/centrometal_boiler/sensors/WebBoilerGenericSensor.py
@@ -142,7 +142,7 @@ class WebBoilerGenericSensor(SensorEntity):
     def create_conf_entities(hass: HomeAssistant, device) -> list[SensorEntity]:
         entities = []
         generic_sensors = dict()
-        if device["type"] == "peltec":
+        if device["type"] in ["peltec", "compact"]:
             generic_sensors = PELTEC_GENERIC_SENSORS
         elif device["type"] == "cmpelet":
             generic_sensors = CM_PELET_SET_GENERIC_SENSORS

--- a/custom_components/centrometal_boiler/switch.py
+++ b/custom_components/centrometal_boiler/switch.py
@@ -20,11 +20,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     unique_id = config_entry.data[CONF_EMAIL]
     web_boiler_client = hass.data[DOMAIN][unique_id][WEB_BOILER_CLIENT]
     for device in web_boiler_client.data.values():
-        if (
-            device["type"] == "peltec"
-            or device["type"] == "cmpelet"
-            or device["type"] == "biopl"
-        ):
+        if device["type"] in ["peltec", "compact", "cmpelet", "biopl"]:
             entities.append(WebBoilerPowerSwitch(hass, device))
         for circuit in device["circuits"].values():
             entities.append(


### PR DESCRIPTION
The PelTec Compact is a newer model. Should be mostly the same as the "peltec" type so I'm just added `or` conditions on every check for `device["type"] == "peltec"`. Seems to work fine with my boiler.