### PR TITLE
Allow not having the product name as prefix + typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The following devices are supported, other may work with CM WiFi-Box.
 ## Services
 
 `centrometal_boiler.turn`
-Start or stop the bolier..
+Start or stop the boiler..
 
 ## Development
 

--- a/custom_components/centrometal_boiler/__init__.py
+++ b/custom_components/centrometal_boiler/__init__.py
@@ -46,11 +46,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     _LOGGER.debug("Setting up Centrometal Boiler System component")
 
     prefix = entry.data[CONF_PREFIX] if (CONF_PREFIX in entry.data) else ""
+    product_prefix = entry.data['product_prefix'] if ('product_prefix' in entry.data) else True
     web_boiler_system = WebBoilerSystem(
         hass,
         username=entry.data[CONF_EMAIL],
         password=entry.data[CONF_PASSWORD],
         prefix=prefix,
+        product_prefix=product_prefix,
     )
 
     unique_id = entry.data[CONF_EMAIL]
@@ -86,7 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 class WebBoilerSystem:
     """A Centrometal Boiler System class."""
 
-    def __init__(self, hass, *, username, password, prefix):
+    def __init__(self, hass, *, username, password, prefix, product_prefix):
         """Initialize the Centrometal Boiler System."""
         self._hass = hass
         self.username = username
@@ -94,6 +96,7 @@ class WebBoilerSystem:
         self.prefix = prefix.rstrip()
         if len(self.prefix) > 0:
             self.prefix = self.prefix + " "
+        self.product_prefix = product_prefix
         self.web_boiler_client = WebBoilerClient()
         self.last_relogin_timestamp = datetime.datetime.timestamp(
             datetime.datetime.now()

--- a/custom_components/centrometal_boiler/config_flow.py
+++ b/custom_components/centrometal_boiler/config_flow.py
@@ -31,6 +31,7 @@ class CentrometalBoilerConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAI
         fields[vol.Required(CONF_EMAIL)] = str
         fields[vol.Required(CONF_PASSWORD)] = str
         fields[vol.Optional(CONF_PREFIX)] = str
+        fields[vol.Optional('product_prefix')] = bool
 
         return self.async_show_form(
             step_id="user", data_schema=vol.Schema(fields), errors=errors
@@ -67,6 +68,7 @@ class CentrometalBoilerConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAI
                 CONF_EMAIL: user_input[CONF_EMAIL],
                 CONF_PASSWORD: user_input[CONF_PASSWORD],
                 CONF_PREFIX: user_input.get(CONF_PREFIX, ""),
+                'product_prefix': user_input.get('product_prefix', ""),
             },
         )
 

--- a/custom_components/centrometal_boiler/sensors/WebBoilerGenericSensor.py
+++ b/custom_components/centrometal_boiler/sensors/WebBoilerGenericSensor.py
@@ -37,7 +37,10 @@ class WebBoilerGenericSensor(SensorEntity):
         self._serial = device["serial"]
         self._parameter_name = parameter["name"]
         self._product = device["product"]
-        self._name = format_name(hass, device, f"{self._product} {self._description}")
+        if self.web_boiler_system.product_prefix == True:
+            self._name = format_name(hass, device, f"{self._product} {self._description}")
+        else:
+            self._name = format_name(hass, device, self._description)
         self._unique_id = f"{self._serial}-{self._parameter_name}"
         #
         self.added_to_hass = False

--- a/custom_components/centrometal_boiler/services.yaml
+++ b/custom_components/centrometal_boiler/services.yaml
@@ -1,1 +1,1 @@
-# Describes the format for available services for web bolier
+# Describes the format for available services for web boiler

--- a/custom_components/centrometal_boiler/strings.json
+++ b/custom_components/centrometal_boiler/strings.json
@@ -15,7 +15,8 @@
         "data": {
           "email": "[%key:common::config_flow::data::email%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "prefix": "[%key:common::config_flow::data::prefix%]"
+          "prefix": "[%key:common::config_flow::data::prefix%]",
+          "product_prefix": "[%key:common::config_flow::data::product_prefix%]"
         }
       }
     }

--- a/custom_components/centrometal_boiler/translations/en.json
+++ b/custom_components/centrometal_boiler/translations/en.json
@@ -15,7 +15,8 @@
         "data": {
           "email": "E-mail",
           "password": "Password",
-          "prefix": "Prefix (leave empty if not needed to prefix all entities)"
+          "prefix": "Prefix (leave empty if not needed to prefix all entities)",
+          "product_prefix": "Prefix all sensors with the boiler's name"
         }
       }
     }


### PR DESCRIPTION
Since I doubt many of us have multiple boilers, the vast majority of entities are better off not having the product name as a prefix. For me it's especially egregious, as I have "PelTec Compact" as product name, which basically takes up the whole space when showing an entity on a card or whatever.

Defaults to true for existing installs, but I haven't found out how to make it checked by default on the config UI.

I didn't make a constant for the key of this new setting since it's not pre-existing like the others, please point me to where you want it if you do.