### PR TITLE
Add sensor for displaying estimated pellet percentage

### DIFF
--- a/custom_components/centrometal_boiler/sensor.py
+++ b/custom_components/centrometal_boiler/sensor.py
@@ -13,6 +13,7 @@ from .sensors.WebBoilerGenericSensor import WebBoilerGenericSensor
 from .sensors.WebBoilerConfigurationSensor import WebBoilerConfigurationSensor
 from .sensors.WebBoilerWorkingTableSensor import WebBoilerWorkingTableSensor
 from .sensors.WebBoilerPelletLevelSensor import WebBoilerPelletLevelSensor
+from .sensors.WebBoilerFuelPercentageSensor import WebBoilerFuelPercentageSensor
 from .sensors.WebBoilerCurrentTimeSensor import WebBoilerCurrentTimeSensor
 from .sensors.WebBoilerFireGridSensor import WebBoilerFireGridSensor
 from .sensors.WebBoilerHeatingCircuitSensor import WebBoilerHeatingCircuitSensor
@@ -39,6 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
         )
         if device["type"] in ["peltec", "compact", "biopl"]:
             entities.extend(WebBoilerPelletLevelSensor.create_entities(hass, device))
+            entities.extend(WebBoilerFuelPercentageSensor.create_entities(hass, device))
         if device["type"] in ["peltec", "compact"]:
             entities.extend(WebBoilerFireGridSensor.create_entities(hass, device))
         entities.extend(WebBoilerGenericSensor.create_conf_entities(hass, device))

--- a/custom_components/centrometal_boiler/sensors/WebBoilerFuelPercentageSensor.py
+++ b/custom_components/centrometal_boiler/sensors/WebBoilerFuelPercentageSensor.py
@@ -1,0 +1,58 @@
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.core import HomeAssistant
+import logging
+
+from .WebBoilerGenericSensor import WebBoilerGenericSensor
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class WebBoilerFuelPercentageSensor(WebBoilerGenericSensor):
+    """Fuel percentage sensor that handles late arrival of B_razP parameter."""
+
+    async def async_added_to_hass(self):
+        """Subscribe to events and check for real parameter."""
+        # Try to get the real parameter now
+        try:
+            if self._device.has_parameter("B_razP"):
+                self.parameter = self._device.get_parameter("B_razP")
+                _LOGGER.debug(
+                    "WebBoilerFuelPercentageSensor connected to real B_razP parameter"
+                )
+        except Exception:
+            pass
+
+        # Call parent to set up subscription
+        await super().async_added_to_hass()
+
+    @property
+    def native_value(self):
+        """Return the percentage value."""
+        try:
+            return int(self.parameter["value"])
+        except (ValueError, TypeError, KeyError):
+            return None
+
+    @property
+    def native_unit_of_measurement(self):
+        return "%"
+
+    @staticmethod
+    def create_entities(hass: HomeAssistant, device) -> list[SensorEntity]:
+        entities = []
+        try:
+            param = device.get_parameter("B_razP")
+        except Exception:
+            # Create with placeholder - will update when B_razP arrives
+            param = {"name": "B_razP", "value": 0, "used": True}
+
+        sensor = WebBoilerFuelPercentageSensor(
+            hass,
+            device,
+            ["%", "mdi:percent", None, "Fuel level"],
+            param,
+        )
+        # Store device reference for later parameter lookup
+        sensor._device = device
+        entities.append(sensor)
+        return entities


### PR DESCRIPTION
It is posible to enable a fuel percentage estimation and this PR will expose the value to the Home Assistant

<img width="817" height="505" alt="Webapp" src="https://github.com/user-attachments/assets/2062f464-281e-4aad-834a-4c943eee8a22" />

